### PR TITLE
Potential fix for code scanning alert no. 4092: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/ReuelAlbert-Dev/firefox/security/code-scanning/4092](https://github.com/ReuelAlbert-Dev/firefox/security/code-scanning/4092)

To fix the problem, explicitly declare the `permissions` block at the top level of the workflow (applies to all jobs unless they override). The single job (`build`) does not require anything except read access to repository contents (as it only checks out code and prints hello world). Therefore, add:

```yaml
permissions:
  contents: read
```

right after the `name: CI` line (before the `on:` block). No other functional changes are needed, and this will not alter the workflow's runtime behavior.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
