### PR TITLE
Potential fix for code scanning alert no. 4: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/third_party/webkit/PerformanceTests/ARES-6/Air/strip-hash.rb
+++ b/third_party/webkit/PerformanceTests/ARES-6/Air/strip-hash.rb
@@ -5,6 +5,6 @@
 
 ARGV.each {
     | filename |
-    IO::write(filename, IO::read(filename).lines.reject{|v| v =~ /hash/i}.join())
+    File.write(filename, File.read(filename).lines.reject { |v| v =~ /hash/i }.join())
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/ReuelAlbert-Dev/firefox/security/code-scanning/4](https://github.com/ReuelAlbert-Dev/firefox/security/code-scanning/4)

To fix this issue, replace the vulnerable usages of `IO.read` and `IO.write` with their corresponding `File.read` and `File.write` methods. `File.read` and `File.write` do not interpret filenames beginning with a `|` as shell commands and are safe for arbitrary filenames. No change in functionality will occur because `File.read` and `File.write` are API-compatible for these calls. The affected region is line 8 in `third_party/webkit/PerformanceTests/ARES-6/Air/strip-hash.rb`, which should be updated to use `File.read` and `File.write` instead of `IO.read` and `IO.write`. No additional libraries or method definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
