### PR TITLE
Potential fix for code scanning alert no. 4206: Code injection

### DIFF
--- a/testing/web-platform/tests/tools/third_party/websockets/tests/sync/server.py
+++ b/testing/web-platform/tests/tools/third_party/websockets/tests/sync/server.py
@@ -1,6 +1,7 @@
 import contextlib
 import ssl
 import threading
+import ast
 
 from websockets.sync.server import *
 
@@ -31,7 +32,11 @@ def do_nothing(ws):
 
 def eval_shell(ws):
     for expr in ws:
-        value = eval(expr)
+        try:
+            value = ast.literal_eval(expr)
+        except (ValueError, SyntaxError):
+            # Fall back to echoing the original expression on invalid input
+            value = expr
         ws.send(str(value))
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/ReuelAlbert-Dev/firefox/security/code-scanning/4206](https://github.com/ReuelAlbert-Dev/firefox/security/code-scanning/4206)

In general, the fix is to stop using `eval` on data read from the WebSocket (`ws`) and instead restrict what the server does with incoming messages. For this particular test helper, we need to preserve its functionality for tests that use `EvalShellMixin.assertEval`, which currently sends an expression string and expects some value back. A minimal change that preserves behavior while eliminating arbitrary code execution is to limit evaluation to a safe, non-executable subset of Python literals using `ast.literal_eval`, which only evaluates Python literal structures (strings, numbers, tuples, lists, dicts, booleans, and `None`) and does not allow arbitrary function calls or attribute access.

Concretely, in `testing/web-platform/tests/tools/third_party/websockets/tests/sync/server.py`, we should:
- Import the standard `ast` module at the top of the file.
- Replace the call `value = eval(expr)` in `eval_shell` with a call to `ast.literal_eval(expr)` inside a `try`/`except`.  
  - On success, send the stringified result as before.
  - On failure (e.g., not a valid literal), send back an error string or the original expression so tests can detect invalid input. Since we must avoid changing existing functionality where possible, the least disruptive behavior is to continue to send something back for every input; returning the original expression on failure preserves the “round-trip” nature for non-literal values without executing them.

These edits are limited to the shown file and do not change the external interface: `eval_shell` still iterates over `ws` and calls `ws.send(str(...))` for each received message, and all function signatures remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
